### PR TITLE
Added password hashing for signup endpoint

### DIFF
--- a/dataface.cabal
+++ b/dataface.cabal
@@ -28,6 +28,7 @@ library
                      , mtl
                      , resource-pool
                      , scotty
+                     , scotty-cookie
                      , text
                      , transformers
                      , tuple

--- a/src/Data.hs
+++ b/src/Data.hs
@@ -6,13 +6,12 @@ module Data (ServerState (..), WebM (..), constructState, querySearch, queryMovi
 import Control.Monad.Trans (liftIO)
 import Control.Monad.Trans.Reader (ReaderT (..))
 import Crypto.BCrypt
-import Data.ByteString.Char8 (pack)
 import Data.List (nub)
 import Data.Maybe (fromJust)
 import Data.Map.Strict (fromList, (!))
 import Data.Monoid ((<>))
 import Data.Pool (Pool, createPool)
-import Data.Text (Text, unpack, toLower)
+import Data.Text (Text, toLower)
 import Data.Tuple.Select (sel1, sel2, sel3)
 import Data.Typeable (typeOf)
 import Database.Bolt

--- a/stack.yaml
+++ b/stack.yaml
@@ -41,6 +41,7 @@ packages:
 # (e.g., acme-missiles-0.3)
 extra-deps:
 - hasbolt-0.1.0.2
+- scotty-cookie-0.1.0.3
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
Also made some progress into setting login cookies. Added a helpful package (`scotty-cookies`) and set relevant login cookies on submission of the login form. Will likely refactor the frontend so that the browser actually goes to the login endpoint and is redirected back to the main page, since otherwise cookies cannot be set.

`files(thisPR)` ∩ `files(otherPR)` = ∅ so merging should be easy.